### PR TITLE
Game outcome

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,8 @@ Metrics/BlockLength:
   - spec/prompt_spec.rb
   - spec/board_spec.rb
   - spec/outcome_checker_spec.rb
+Metrics/ParameterLists:
+  Enabled: false
 AllCops:
   NewCops: enable
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Naming/PredicateName:
 Metrics/BlockLength:
   Exclude:
   - spec/game_spec.rb
+  - spec/game_looper_spec.rb
   - spec/prompt_spec.rb
   - spec/board_spec.rb
   - spec/outcome_checker_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,14 @@ Style/AccessorMethodName:
   Enabled: false
 Lint/EmptyClass:
   Enabled: false
+Naming/PredicateName:
+  Enabled: false
 Metrics/BlockLength:
   Exclude:
   - spec/game_spec.rb
   - spec/prompt_spec.rb
   - spec/board_spec.rb
+  - spec/outcome_checker_spec.rb
 AllCops:
   NewCops: enable
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Metrics/BlockLength:
   - spec/prompt_spec.rb
   - spec/board_spec.rb
   - spec/outcome_checker_spec.rb
+Metrics/MethodLength:
+  Exclude:
+  - spec/display_spec.rb
 Metrics/ParameterLists:
   Enabled: false
 AllCops:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ Style/AccessorMethodName:
   Enabled: false
 Style/WordArray:
   Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
 Lint/EmptyClass:
   Enabled: false
 Naming/PredicateName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/AccessorMethodName:
   Enabled: false
+Style/WordArray:
+  Enabled: false
 Lint/EmptyClass:
   Enabled: false
 Naming/PredicateName:

--- a/bin/run
+++ b/bin/run
@@ -7,11 +7,13 @@ require_relative '../lib/display'
 require_relative '../lib/prompt'
 require_relative '../lib/board'
 require_relative '../lib/number_validator'
+require_relative '../lib/outcome_checker'
 require_relative '../lib/player'
 
 console = Console.new(stdout: $stdout, stdin: $stdin)
+outcome_checker = OutcomeChecker.new
 display = Display.new
-board = Board.new
+board = Board.new(outcome_checker:)
 number_validator = NumberValidator.new
 prompt = Prompt.new(console:, number_validator:,
                     board:)

--- a/bin/run
+++ b/bin/run
@@ -11,15 +11,15 @@ require_relative '../lib/outcome_checker'
 require_relative '../lib/player'
 
 console = Console.new(stdout: $stdout, stdin: $stdin)
-outcome_checker = OutcomeChecker.new
+board = Board.new
+outcome_checker = OutcomeChecker.new(board:)
 display = Display.new
-board = Board.new(outcome_checker:)
 number_validator = NumberValidator.new
 prompt = Prompt.new(console:, number_validator:,
                     board:)
 player_one = Player.new(marker: 'X')
 player_two = Player.new(marker: 'O')
 players = [player_one, player_two]
-game_looper = GameLooper.new(console:, display:, prompt:, board:, players:)
+game_looper = GameLooper.new(console:, display:, prompt:, board:, players:, outcome_checker:)
 game = Game.new(console:, game_looper:)
 game.run

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -2,10 +2,8 @@ require 'pry'
 
 class Board
   attr_accessor :values
-  attr_reader :outcome_checker
 
-  def initialize(outcome_checker:)
-    @outcome_checker = outcome_checker
+  def initialize
     @values = (1..9).to_a
   end
 
@@ -27,14 +25,6 @@ class Board
   def available?(input)
     space = values[input - 1]
     space.is_a?(Integer)
-  end
-
-  def has_win?
-    outcome_checker.win?(self)
-  end
-
-  def has_draw?
-    outcome_checker.draw?(self)
   end
 
   def lines

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,8 +1,8 @@
 require 'pry'
 
 class Board
-  attr_accessor :values, :values_grid
-  attr_reader :outcome_checker, :dimension
+  attr_accessor :values
+  attr_reader :outcome_checker
 
   def initialize(outcome_checker:)
     @outcome_checker = outcome_checker
@@ -13,7 +13,7 @@ class Board
     index = (row * dimension) + column
     values[index]
   end
-  
+
   def mark_space(token, space)
     values[space - 1] = token
   end
@@ -51,8 +51,8 @@ class Board
 
   private
 
-  def dimension 
-    dimension = Math.sqrt(values.length).to_i
+  def dimension
+    Math.sqrt(values.length).to_i
   end
 
   def values_grid

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,20 +1,19 @@
 require 'pry'
 
 class Board
-  attr_accessor :values
+  attr_accessor :values, :values_grid
   attr_reader :outcome_checker, :dimension
 
   def initialize(outcome_checker:)
     @outcome_checker = outcome_checker
     @values = (1..9).to_a
-    @dimension = Math.sqrt(values.length).to_i
   end
 
   def get_space(row, column)
     index = (row * dimension) + column
     values[index]
   end
-
+  
   def mark_space(token, space)
     values[space - 1] = token
   end
@@ -39,11 +38,11 @@ class Board
   end
 
   def rows
-    row_numbers.map { |row_number| row(row_number) }
+    values_grid
   end
 
   def columns
-    column_numbers.map { |column_number| column(column_number) }
+    values_grid.transpose
   end
 
   def diagonals
@@ -52,26 +51,14 @@ class Board
 
   private
 
-  def row_numbers
-    max_row_number = dimension - 1
-    (0..max_row_number).to_a
+  def dimension 
+    dimension = Math.sqrt(values.length).to_i
   end
 
-  def column_numbers
-    max_column_number = dimension - 1
-    (0..max_column_number).to_a
-  end
-
-  def row(row_number)
-    column_numbers.map do |column_number|
-      get_space(row_number, column_number)
-    end
-  end
-
-  def column(column_number)
-    row_numbers.map do |row_number|
-      get_space(row_number, column_number)
-    end
+  def values_grid
+    grid = []
+    values.each_slice(dimension) { |row| grid << row }
+    grid
   end
 
   def left_diagonal

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -27,7 +27,7 @@ class Board
     space.is_a?(Integer)
   end
 
-  def lines
+  def combinations
     rows + columns + diagonals
   end
 

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -63,11 +63,13 @@ class Board
 
   def left_diagonal
     left_diagonal = []
-    current_row_or_column = 0
+    current_row = 0
+    current_column = 0
 
     dimension.times do
-      left_diagonal << get_space(current_row_or_column, current_row_or_column)
-      current_row_or_column += 1
+      left_diagonal << get_space(current_row, current_column)
+      current_row += 1
+      current_column += 1
     end
 
     left_diagonal

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -16,12 +16,6 @@ class Board
     values[space - 1] = token
   end
 
-  def full?
-    open_board = (1..values.length).to_a
-    open_spaces = values & open_board
-    open_spaces.empty?
-  end
-
   def available?(input)
     space = values[input - 1]
     space.is_a?(Integer)

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -37,6 +37,12 @@ class Board
     outcome_checker.draw?(self)
   end
 
+  def lines
+    rows + columns + diagonals
+  end
+
+  private
+
   def rows
     values_grid
   end
@@ -49,10 +55,12 @@ class Board
     [left_diagonal, right_diagonal]
   end
 
-  private
-
   def dimension
     Math.sqrt(values.length).to_i
+  end
+
+  def max_index
+    values.length - 1
   end
 
   def values_grid
@@ -62,30 +70,19 @@ class Board
   end
 
   def left_diagonal
-    left_diagonal = []
-    current_row = 0
-    current_column = 0
-
-    dimension.times do
-      left_diagonal << get_space(current_row, current_column)
-      current_row += 1
-      current_column += 1
-    end
-
-    left_diagonal
+    index_range = 0..max_index
+    divisor = dimension + 1
+    diagonal_values(index_range, divisor)
   end
 
   def right_diagonal
-    right_diagonal = []
-    current_row = 0
-    current_column = dimension - 1
+    index_range = (dimension - 1)..(max_index - 1)
+    divisor = dimension - 1
+    diagonal_values(index_range, divisor)
+  end
 
-    dimension.times do
-      right_diagonal << get_space(current_row, current_column)
-      current_row += 1
-      current_column -= 1
-    end
-
-    right_diagonal
+  def diagonal_values(index_range, divisor)
+    diagonal_indices = index_range.filter { |index| (index % divisor).zero? }
+    diagonal_indices.map { |index| values[index] }
   end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,12 +1,17 @@
+require 'pry'
+
 class Board
   attr_accessor :values
+  attr_reader :outcome_checker, :dimension
 
-  def initialize
+  def initialize(outcome_checker:)
+    @outcome_checker = outcome_checker
     @values = (1..9).to_a
+    @dimension = Math.sqrt(values.length).to_i
   end
 
   def get_space(row, column)
-    index = (row * 3) + column
+    index = (row * dimension) + column
     values[index]
   end
 
@@ -15,7 +20,7 @@ class Board
   end
 
   def full?
-    open_board = (1..9).to_a
+    open_board = (1..values.length).to_a
     open_spaces = values & open_board
     open_spaces.empty?
   end
@@ -23,5 +28,75 @@ class Board
   def available?(input)
     space = values[input - 1]
     space.is_a?(Integer)
+  end
+
+  def has_win?
+    outcome_checker.win?(self)
+  end
+
+  def has_draw?
+    outcome_checker.draw?(self)
+  end
+
+  def rows
+    row_numbers.map { |row_number| row(row_number) }
+  end
+
+  def columns
+    column_numbers.map { |column_number| column(column_number) }
+  end
+
+  def diagonals
+    [left_diagonal, right_diagonal]
+  end
+
+  private
+
+  def row_numbers
+    max_row_number = dimension - 1
+    (0..max_row_number).to_a
+  end
+
+  def column_numbers
+    max_column_number = dimension - 1
+    (0..max_column_number).to_a
+  end
+
+  def row(row_number)
+    column_numbers.map do |column_number|
+      get_space(row_number, column_number)
+    end
+  end
+
+  def column(column_number)
+    row_numbers.map do |row_number|
+      get_space(row_number, column_number)
+    end
+  end
+
+  def left_diagonal
+    left_diagonal = []
+    current_row_or_column = 0
+
+    dimension.times do
+      left_diagonal << get_space(current_row_or_column, current_row_or_column)
+      current_row_or_column += 1
+    end
+
+    left_diagonal
+  end
+
+  def right_diagonal
+    right_diagonal = []
+    current_row = 0
+    current_column = dimension - 1
+
+    dimension.times do
+      right_diagonal << get_space(current_row, current_column)
+      current_row += 1
+      current_column -= 1
+    end
+
+    right_diagonal
   end
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -10,7 +10,6 @@ class Game
 
   def run
     welcome_players
-    # configure_game
     game_looper.loop
     goodbye_players
   end

--- a/lib/game_looper.rb
+++ b/lib/game_looper.rb
@@ -11,6 +11,7 @@ class GameLooper
 
   def loop
     take_turns(players) until game_is_over
+    # until board.has_outcome { take_turns(players) }
     display_board
   end
 

--- a/lib/game_looper.rb
+++ b/lib/game_looper.rb
@@ -1,12 +1,13 @@
 require 'pry'
 
 class GameLooper
-  def initialize(console:, display:, prompt:, board:, players:)
+  def initialize(console:, display:, prompt:, board:, players:, outcome_checker:)
     @console = console
     @display = display
     @prompt = prompt
     @board = board
     @players = players
+    @outcome_checker = outcome_checker
   end
 
   def loop
@@ -17,10 +18,10 @@ class GameLooper
 
   private
 
-  attr_reader :console, :display, :prompt, :board, :players
+  attr_reader :console, :display, :prompt, :board, :players, :outcome_checker
 
   def game_is_over
-    board.has_draw? || board.has_win?
+    outcome_checker.draw? || outcome_checker.win?
   end
 
   def take_turns(players)

--- a/lib/game_looper.rb
+++ b/lib/game_looper.rb
@@ -12,7 +12,6 @@ class GameLooper
 
   def loop
     take_turns(players) until game_is_over
-    # until board.has_outcome { take_turns(players) }
     display_board
   end
 

--- a/lib/game_looper.rb
+++ b/lib/game_looper.rb
@@ -1,8 +1,6 @@
 require 'pry'
 
 class GameLooper
-  # private
-
   def initialize(console:, display:, prompt:, board:, players:)
     @console = console
     @display = display
@@ -21,8 +19,7 @@ class GameLooper
   attr_reader :console, :display, :prompt, :board, :players
 
   def game_is_over
-    # binding.pry
-    board.full?
+    board.has_draw? || board.has_win?
   end
 
   def take_turns(players)

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -1,9 +1,8 @@
 class OutcomeChecker
-
   def initialize(board:)
     @board = board
   end
-  
+
   def win?
     winning_combo?(board.lines)
   end

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -8,7 +8,8 @@ class OutcomeChecker
   end
 
   def draw?
-    board.full? && !win?
+    # board.full? && !win?
+    full_board?(board.combinations) && !win?
   end
 
   private
@@ -21,5 +22,9 @@ class OutcomeChecker
 
   def all_equal?(combination)
     combination.uniq.length == 1
+  end
+
+  def full_board?(combinations)
+    combinations.none? { |combination| combination.any?(Integer) }
   end
 end

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -4,7 +4,7 @@ class OutcomeChecker
   end
 
   def win?
-    winning_combo?(board.lines)
+    winning_combo?(board.combinations)
   end
 
   def draw?
@@ -15,11 +15,11 @@ class OutcomeChecker
 
   attr_reader :board
 
-  def winning_combo?(lines)
-    lines.any? { |line| all_equal?(line) }
+  def winning_combo?(combinations)
+    combinations.any? { |combination| all_equal?(combination) }
   end
 
-  def all_equal?(line)
-    line.uniq.length == 1
+  def all_equal?(combination)
+    combination.uniq.length == 1
   end
 end

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -16,8 +16,7 @@ class OutcomeChecker
   attr_reader :board
 
   def winning_combo?(lines)
-    line_statuses = lines.map { |line| all_equal?(line) }
-    line_statuses.include?(true)
+    lines.any? { |line| all_equal?(line) }
   end
 
   def all_equal?(line)

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -1,13 +1,20 @@
 class OutcomeChecker
-  def win?(board)
+
+  def initialize(board:)
+    @board = board
+  end
+  
+  def win?
     winning_combo?(board.lines)
   end
 
-  def draw?(board)
-    board.full? && !win?(board)
+  def draw?
+    board.full? && !win?
   end
 
   private
+
+  attr_reader :board
 
   def winning_combo?(lines)
     line_statuses = lines.map { |line| all_equal?(line) }

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -1,6 +1,6 @@
 class OutcomeChecker
   def win?(board)
-    winning_combo?(board.rows) || winning_combo?(board.columns) || winning_combo?(board.diagonals)
+    winning_combo?(board.lines)
   end
 
   def draw?(board)

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -1,0 +1,20 @@
+class OutcomeChecker
+  def win?(board)
+    winning_combo?(board.rows) || winning_combo?(board.columns) || winning_combo?(board.diagonals)
+  end
+
+  def draw?(board)
+    board.full? && !win?(board)
+  end
+
+  private
+
+  def winning_combo?(lines)
+    line_statuses = lines.map { |line| all_equal?(line) }
+    line_statuses.include?(true)
+  end
+
+  def all_equal?(line)
+    line.uniq.length == 1
+  end
+end

--- a/lib/outcome_checker.rb
+++ b/lib/outcome_checker.rb
@@ -8,7 +8,6 @@ class OutcomeChecker
   end
 
   def draw?
-    # board.full? && !win?
     full_board?(board.combinations) && !win?
   end
 

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,5 +1,4 @@
 class Player
-
   attr_reader :marker
 
   def initialize(marker:)

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,6 +1,4 @@
 class Player
-  # Should this be a value object?
-  # Should it have a select method?
 
   attr_reader :marker
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -61,7 +61,7 @@ describe 'Board' do
     end
   end
 
-  describe '#lines' do
+  describe '#combinations' do
     context 'given an empty board' do
       it 'returns the correct values' do
         board = Board.new
@@ -72,13 +72,13 @@ describe 'Board' do
           7, 8, 9
         ]
 
-        expected_lines = [
+        expected_combinations = [
           [1, 2, 3], [4, 5, 6], [7, 8, 9],
           [1, 4, 7], [2, 5, 8], [3, 6, 9],
           [1, 5, 9], [3, 5, 7]
         ]
 
-        expect(board.lines).to eq(expected_lines)
+        expect(board.combinations).to eq(expected_combinations)
       end
     end
 
@@ -92,13 +92,13 @@ describe 'Board' do
           'O', 'X', 'O'
         ]
 
-        expected_lines = [
+        expected_combinations = [
           ['O', 'O', 'X'], ['X', 'X', 'O'], ['O', 'X', 'O'],
           ['O', 'X', 'O'], ['O', 'X', 'X'], ['X', 'O', 'O'],
           ['O', 'X', 'O'], ['X', 'X', 'O']
         ]
 
-        expect(board.lines).to eq(expected_lines)
+        expect(board.combinations).to eq(expected_combinations)
       end
     end
   end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -1,9 +1,24 @@
 require 'board'
 
+class TestOutcomeChecker
+end
+
 describe 'Board' do
+  context 'given a row and column number (from 0 - 2)' do
+    it '#get_space returns the correct value for the given coordinates' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      board.values = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+      expect(board.get_space(0, 0)).to eq(1)
+      expect(board.get_space(2, 2)).to eq(9)
+    end
+  end
+
   context '#mark_space' do
     it 'places an X in the selected space on the board' do
-      board = Board.new
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
       token = 'X'
       space = 1
 
@@ -17,7 +32,8 @@ describe 'Board' do
 
   context '#full?' do
     it 'returns true when the board is full' do
-      board = Board.new
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
 
       board.values = %w[X O O X X O X X O]
 
@@ -25,7 +41,8 @@ describe 'Board' do
     end
 
     it 'returns false when the board is not full' do
-      board = Board.new
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
 
       board.values = ['X', 2, 'O', 'X', 'X', 'O', 'X', 'X', 'O']
 
@@ -35,17 +52,113 @@ describe 'Board' do
 
   context '#available?' do
     it 'returns true when the space is available' do
-      board = Board.new
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+
       board.values = ['X', 2, 3, 'O', 5, 6, 'X', 8, 9]
 
       expect(board.available?(6)).to eq(true)
     end
 
     it 'returns false when the space is not available' do
-      board = Board.new
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+
       board.values = ['X', 2, 3, 'O', 5, 6, 'X', 8, 9]
 
       expect(board.available?(7)).to eq(false)
+    end
+  end
+
+  context '#rows' do
+    it 'returns the correct row values' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      board.values = [
+        'O', 2, 'X',
+        4, 'X', 'O',
+        'O', 'X', 9
+      ]
+      expected_rows = [
+        ['O', 2, 'X'],
+        [4, 'X', 'O'],
+        ['O', 'X', 9]
+      ]
+
+      expect(board.rows).to eq(expected_rows)
+    end
+  end
+
+  context '#columns' do
+    it 'returns the correct column values' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      board.values = [
+        'O', 2, 'X',
+        4, 'X', 'O',
+        'O', 'X', 9
+      ]
+      expected_columns = [
+        ['O', 4, 'O'],
+        [2, 'X', 'X'],
+        ['X', 'O', 9]
+      ]
+
+      expect(board.columns).to eq(expected_columns)
+    end
+  end
+
+  context '#diagonals' do
+    it 'returns the correct diagonal values' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      board.values = [
+        'O', 2, 'X',
+        4, 'X', 'O',
+        'O', 'X', 9
+      ]
+      expected_diagonals = [
+        ['O', 'X', 9],
+        %w[X X O]
+      ]
+
+      expect(board.diagonals).to eq(expected_diagonals)
+    end
+  end
+
+  context '#has_draw?' do
+    it 'returns true when the outcome checker finds a draw' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      allow(outcome_checker).to receive(:draw?).and_return(true)
+
+      expect(board.has_draw?).to eq(true)
+    end
+
+    it 'returns false when the outcome checker does not find a draw' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      allow(outcome_checker).to receive(:draw?).and_return(false)
+
+      expect(board.has_draw?).to eq(false)
+    end
+  end
+
+  context '#has_win?' do
+    it 'returns true when the outcome checker finds a win' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      allow(outcome_checker).to receive(:win?).and_return(true)
+
+      expect(board.has_win?).to eq(true)
+    end
+
+    it 'returns false when the outcome checker does not find a win' do
+      outcome_checker = TestOutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      allow(outcome_checker).to receive(:win?).and_return(false)
+
+      expect(board.has_win?).to eq(false)
     end
   end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -119,36 +119,4 @@ describe 'Board' do
       end
     end
   end
-
-  # context '#has_draw?' do
-  #   it 'returns true when the outcome checker finds a draw' do
-  #     outcome_checker = TestOutcomeChecker.new(test_draw: true, test_win: false)
-  #     board = Board.new(outcome_checker:)
-
-  #     expect(board.has_draw?).to eq(true)
-  #   end
-
-  #   it 'returns false when the outcome checker does not find a draw' do
-  #     outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
-  #     board = Board.new(outcome_checker:)
-
-  #     expect(board.has_draw?).to eq(false)
-  #   end
-  # end
-
-  # context '#has_win?' do
-  #   it 'returns true when the outcome checker finds a win' do
-  #     outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: true)
-  #     board = Board.new(outcome_checker:)
-
-  #     expect(board.has_win?).to eq(true)
-  #   end
-
-  #   it 'returns false when the outcome checker does not find a win' do
-  #     outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
-  #     board = Board.new(outcome_checker:)
-
-  #     expect(board.has_win?).to eq(false)
-  #   end
-  # end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -1,22 +1,5 @@
 require 'board'
 
-class TestOutcomeChecker
-  attr_reader :test_win, :test_draw
-
-  def initialize(test_win: false, test_draw: false)
-    @test_win = test_win
-    @test_draw = test_draw
-  end
-
-  def win?(_board)
-    test_win
-  end
-
-  def draw?(_board)
-    test_draw
-  end
-end
-
 describe 'Board' do
   context 'given a row and column number (from 0 - 2)' do
     it '#get_space returns the correct value for the given coordinates' do

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -1,6 +1,20 @@
 require 'board'
 
 class TestOutcomeChecker
+  attr_reader :test_win, :test_draw
+
+  def initialize(test_win: false, test_draw: false)
+    @test_win = test_win
+    @test_draw = test_draw
+  end
+
+  def win?(board)
+    test_win
+  end
+
+  def draw?(board)
+    test_draw
+  end
 end
 
 describe 'Board' do
@@ -128,17 +142,15 @@ describe 'Board' do
 
   context '#has_draw?' do
     it 'returns true when the outcome checker finds a draw' do
-      outcome_checker = TestOutcomeChecker.new
+      outcome_checker = TestOutcomeChecker.new(test_draw: true, test_win: false)
       board = Board.new(outcome_checker:)
-      allow(outcome_checker).to receive(:draw?).and_return(true)
 
       expect(board.has_draw?).to eq(true)
     end
 
     it 'returns false when the outcome checker does not find a draw' do
-      outcome_checker = TestOutcomeChecker.new
+      outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
       board = Board.new(outcome_checker:)
-      allow(outcome_checker).to receive(:draw?).and_return(false)
 
       expect(board.has_draw?).to eq(false)
     end
@@ -146,17 +158,15 @@ describe 'Board' do
 
   context '#has_win?' do
     it 'returns true when the outcome checker finds a win' do
-      outcome_checker = TestOutcomeChecker.new
+      outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: true)
       board = Board.new(outcome_checker:)
-      allow(outcome_checker).to receive(:win?).and_return(true)
 
       expect(board.has_win?).to eq(true)
     end
 
     it 'returns false when the outcome checker does not find a win' do
-      outcome_checker = TestOutcomeChecker.new
+      outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
       board = Board.new(outcome_checker:)
-      allow(outcome_checker).to receive(:win?).and_return(false)
 
       expect(board.has_win?).to eq(false)
     end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -25,23 +25,23 @@ describe 'Board' do
     end
   end
 
-  context '#full?' do
-    it 'returns true when the board is full' do
-      board = Board.new
+  # context '#full?' do
+  #   it 'returns true when the board is full' do
+  #     board = Board.new
 
-      board.values = %w[X O O X X O X X O]
+  #     board.values = %w[X O O X X O X X O]
 
-      expect(board.full?).to eq(true)
-    end
+  #     expect(board.full?).to eq(true)
+  #   end
 
-    it 'returns false when the board is not full' do
-      board = Board.new
+  #   it 'returns false when the board is not full' do
+  #     board = Board.new
 
-      board.values = ['X', 2, 'O', 'X', 'X', 'O', 'X', 'X', 'O']
+  #     board.values = ['X', 2, 'O', 'X', 'X', 'O', 'X', 'X', 'O']
 
-      expect(board.full?).to eq(false)
-    end
-  end
+  #     expect(board.full?).to eq(false)
+  #   end
+  # end
 
   context '#available?' do
     it 'returns true when the space is available' do

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -20,8 +20,7 @@ end
 describe 'Board' do
   context 'given a row and column number (from 0 - 2)' do
     it '#get_space returns the correct value for the given coordinates' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
       board.values = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
       expect(board.get_space(0, 0)).to eq(1)
@@ -31,8 +30,7 @@ describe 'Board' do
 
   context '#mark_space' do
     it 'places an X in the selected space on the board' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
       token = 'X'
       space = 1
 
@@ -46,8 +44,7 @@ describe 'Board' do
 
   context '#full?' do
     it 'returns true when the board is full' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
 
       board.values = %w[X O O X X O X X O]
 
@@ -55,8 +52,7 @@ describe 'Board' do
     end
 
     it 'returns false when the board is not full' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
 
       board.values = ['X', 2, 'O', 'X', 'X', 'O', 'X', 'X', 'O']
 
@@ -66,8 +62,7 @@ describe 'Board' do
 
   context '#available?' do
     it 'returns true when the space is available' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
 
       board.values = ['X', 2, 3, 'O', 5, 6, 'X', 8, 9]
 
@@ -75,8 +70,7 @@ describe 'Board' do
     end
 
     it 'returns false when the space is not available' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
 
       board.values = ['X', 2, 3, 'O', 5, 6, 'X', 8, 9]
 
@@ -87,8 +81,7 @@ describe 'Board' do
   describe '#lines' do
     context 'given an empty board' do
       it 'returns the correct values' do
-        outcome_checker = TestOutcomeChecker.new(test_draw: true, test_win: false)
-        board = Board.new(outcome_checker:)
+        board = Board.new
 
         board.values = [
           1, 2, 3,
@@ -108,8 +101,7 @@ describe 'Board' do
 
     context 'given a full board' do
       it 'returns the correct values' do
-        outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
-        board = Board.new(outcome_checker:)
+        board = Board.new
 
         board.values = [
           'O', 'O', 'X',
@@ -128,35 +120,35 @@ describe 'Board' do
     end
   end
 
-  context '#has_draw?' do
-    it 'returns true when the outcome checker finds a draw' do
-      outcome_checker = TestOutcomeChecker.new(test_draw: true, test_win: false)
-      board = Board.new(outcome_checker:)
+  # context '#has_draw?' do
+  #   it 'returns true when the outcome checker finds a draw' do
+  #     outcome_checker = TestOutcomeChecker.new(test_draw: true, test_win: false)
+  #     board = Board.new(outcome_checker:)
 
-      expect(board.has_draw?).to eq(true)
-    end
+  #     expect(board.has_draw?).to eq(true)
+  #   end
 
-    it 'returns false when the outcome checker does not find a draw' do
-      outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
-      board = Board.new(outcome_checker:)
+  #   it 'returns false when the outcome checker does not find a draw' do
+  #     outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
+  #     board = Board.new(outcome_checker:)
 
-      expect(board.has_draw?).to eq(false)
-    end
-  end
+  #     expect(board.has_draw?).to eq(false)
+  #   end
+  # end
 
-  context '#has_win?' do
-    it 'returns true when the outcome checker finds a win' do
-      outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: true)
-      board = Board.new(outcome_checker:)
+  # context '#has_win?' do
+  #   it 'returns true when the outcome checker finds a win' do
+  #     outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: true)
+  #     board = Board.new(outcome_checker:)
 
-      expect(board.has_win?).to eq(true)
-    end
+  #     expect(board.has_win?).to eq(true)
+  #   end
 
-    it 'returns false when the outcome checker does not find a win' do
-      outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
-      board = Board.new(outcome_checker:)
+  #   it 'returns false when the outcome checker does not find a win' do
+  #     outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
+  #     board = Board.new(outcome_checker:)
 
-      expect(board.has_win?).to eq(false)
-    end
-  end
+  #     expect(board.has_win?).to eq(false)
+  #   end
+  # end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -8,11 +8,11 @@ class TestOutcomeChecker
     @test_draw = test_draw
   end
 
-  def win?(board)
+  def win?(_board)
     test_win
   end
 
-  def draw?(board)
+  def draw?(_board)
     test_draw
   end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -25,24 +25,6 @@ describe 'Board' do
     end
   end
 
-  # context '#full?' do
-  #   it 'returns true when the board is full' do
-  #     board = Board.new
-
-  #     board.values = %w[X O O X X O X X O]
-
-  #     expect(board.full?).to eq(true)
-  #   end
-
-  #   it 'returns false when the board is not full' do
-  #     board = Board.new
-
-  #     board.values = ['X', 2, 'O', 'X', 'X', 'O', 'X', 'X', 'O']
-
-  #     expect(board.full?).to eq(false)
-  #   end
-  # end
-
   context '#available?' do
     it 'returns true when the space is available' do
       board = Board.new

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -84,59 +84,47 @@ describe 'Board' do
     end
   end
 
-  context '#rows' do
-    it 'returns the correct row values' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
-      board.values = [
-        'O', 2, 'X',
-        4, 'X', 'O',
-        'O', 'X', 9
-      ]
-      expected_rows = [
-        ['O', 2, 'X'],
-        [4, 'X', 'O'],
-        ['O', 'X', 9]
-      ]
+  describe '#lines' do
+    context 'given an empty board' do
+      it 'returns the correct values' do
+        outcome_checker = TestOutcomeChecker.new(test_draw: true, test_win: false)
+        board = Board.new(outcome_checker:)
 
-      expect(board.rows).to eq(expected_rows)
+        board.values = [
+          1, 2, 3,
+          4, 5, 6,
+          7, 8, 9
+        ]
+
+        expected_lines = [
+          [1, 2, 3], [4, 5, 6], [7, 8, 9],
+          [1, 4, 7], [2, 5, 8], [3, 6, 9],
+          [1, 5, 9], [3, 5, 7]
+        ]
+
+        expect(board.lines).to eq(expected_lines)
+      end
     end
-  end
 
-  context '#columns' do
-    it 'returns the correct column values' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
-      board.values = [
-        'O', 2, 'X',
-        4, 'X', 'O',
-        'O', 'X', 9
-      ]
-      expected_columns = [
-        ['O', 4, 'O'],
-        [2, 'X', 'X'],
-        ['X', 'O', 9]
-      ]
+    context 'given a full board' do
+      it 'returns the correct values' do
+        outcome_checker = TestOutcomeChecker.new(test_draw: false, test_win: false)
+        board = Board.new(outcome_checker:)
 
-      expect(board.columns).to eq(expected_columns)
-    end
-  end
+        board.values = [
+          'O', 'O', 'X',
+          'X', 'X', 'O',
+          'O', 'X', 'O'
+        ]
 
-  context '#diagonals' do
-    it 'returns the correct diagonal values' do
-      outcome_checker = TestOutcomeChecker.new
-      board = Board.new(outcome_checker:)
-      board.values = [
-        'O', 2, 'X',
-        4, 'X', 'O',
-        'O', 'X', 9
-      ]
-      expected_diagonals = [
-        ['O', 'X', 9],
-        %w[X X O]
-      ]
+        expected_lines = [
+          ['O', 'O', 'X'], ['X', 'X', 'O'], ['O', 'X', 'O'],
+          ['O', 'X', 'O'], ['O', 'X', 'X'], ['X', 'O', 'O'],
+          ['O', 'X', 'O'], ['X', 'X', 'O']
+        ]
 
-      expect(board.diagonals).to eq(expected_diagonals)
+        expect(board.lines).to eq(expected_lines)
+      end
     end
   end
 

--- a/spec/display_spec.rb
+++ b/spec/display_spec.rb
@@ -2,8 +2,17 @@ require 'display'
 
 class TestBoardForEmptyBoard
   def get_space(row, column)
-    index = (row * 3) + column
-    index + 1
+    {
+      [0, 0] => 1,
+      [0, 1] => 2,
+      [0, 2] => 3,
+      [1, 0] => 4,
+      [1, 1] => 5,
+      [1, 2] => 6,
+      [2, 0] => 7,
+      [2, 1] => 8,
+      [2, 2] => 9,
+    }[[row, column]]
   end
 end
 

--- a/spec/display_spec.rb
+++ b/spec/display_spec.rb
@@ -11,7 +11,7 @@ class TestBoardForEmptyBoard
       [1, 2] => 6,
       [2, 0] => 7,
       [2, 1] => 8,
-      [2, 2] => 9,
+      [2, 2] => 9
     }[[row, column]]
   end
 end

--- a/spec/game_looper_spec.rb
+++ b/spec/game_looper_spec.rb
@@ -30,6 +30,23 @@ class TestPrompt
   def call(_message, _error_message); end
 end
 
+class TestOutcomeCheckerForGameLooper
+  # attr_reader :test_draw, :test_win
+  def initialize(board:)
+    @board = board
+    # @test_draw = test_draw
+    # @test_win = test_win
+  end
+
+  # def win?
+  #   test_win
+  # end
+
+  # def draw?
+  #   test_draw
+  # end
+end
+
 describe 'Game Looper' do
   context '#loop' do
     it 'loops until there is a draw' do
@@ -37,18 +54,18 @@ describe 'Game Looper' do
       prompt = TestPrompt.new
       board = TestBoard.new
       display = TestDisplay.new
+      outcome_checker = TestOutcomeCheckerForGameLooper.new(board:)
       player_one = TestPlayer.new('X')
       player_two = TestPlayer.new('O')
       players = [player_one, player_two]
 
-      allow(board).to receive(:full?).and_return(false, false, false, false, true)
-      allow(board).to receive(:has_draw?).and_return(false, false, false, false, true)
-      allow(board).to receive(:has_win?).and_return(false, false, false, false, false)
+      allow(outcome_checker).to receive(:draw?).and_return(false, false, false, false, true)
+      allow(outcome_checker).to receive(:win?).and_return(false, false, false, false, false)
 
       allow(display).to receive(:present).and_return('board', 'board', 'board_with_draw')
 
       game_looper = GameLooper.new(console:, prompt:, board:, display:,
-                                   players:)
+                                   players:, outcome_checker:)
 
       game_looper.loop
 
@@ -62,18 +79,18 @@ describe 'Game Looper' do
       prompt = TestPrompt.new
       board = TestBoard.new
       display = TestDisplay.new
+      outcome_checker = TestOutcomeCheckerForGameLooper.new(board:)
       player_one = TestPlayer.new('X')
       player_two = TestPlayer.new('O')
       players = [player_one, player_two]
 
-      allow(board).to receive(:full?).and_return(false, false, false, false, true)
-      allow(board).to receive(:has_draw?).and_return(false, false, false, false, false)
-      allow(board).to receive(:has_win?).and_return(false, false, false, false, true)
+      allow(outcome_checker).to receive(:draw?).and_return(false, false, false, false, false)
+      allow(outcome_checker).to receive(:win?).and_return(false, false, false, false, true)
 
       allow(display).to receive(:present).and_return('board', 'board', 'board_with_win')
 
       game_looper = GameLooper.new(console:, prompt:, board:, display:,
-                                   players:)
+                                   players:, outcome_checker:)
 
       game_looper.loop
 

--- a/spec/game_looper_spec.rb
+++ b/spec/game_looper_spec.rb
@@ -31,20 +31,9 @@ class TestPrompt
 end
 
 class TestOutcomeCheckerForGameLooper
-  # attr_reader :test_draw, :test_win
   def initialize(board:)
     @board = board
-    # @test_draw = test_draw
-    # @test_win = test_win
   end
-
-  # def win?
-  #   test_win
-  # end
-
-  # def draw?
-  #   test_draw
-  # end
 end
 
 describe 'Game Looper' do
@@ -98,31 +87,5 @@ describe 'Game Looper' do
 
       expect(console.messages).to eq(expected_console_messages)
     end
-
-    # it 'gives each player a turn' do
-    #     console = TestConsole.new
-    #     prompt = TestPrompt.new
-    #     board = TestBoard.new
-    #     display = TestDisplay.new
-    #     player_one = TestPlayer.new('X')
-    #     player_two = TestPlayer.new('O')
-    #     players = [player_one, player_two]
-
-    #     allow(board).to receive(:full?).and_return(false, false, true)
-    #     allow(board).to receive(:mark_space).and_return('empty board',
-    #     'board with an X in space 8', 'board with an O in space 2')
-    #     allow(board).to receive(:values).and_return()
-
-    #     allow(display).to receive(:present).and_return()
-
-    #     game_looper = GameLooper.new(console: console, prompt: prompt,
-    #     board: board, display: display, players: players)
-
-    #     game_looper.loop
-
-    #     expected_console_messages = ['empty board', 'board with X in space 8', 'board with O in space 2']
-
-    #     expect(console.messages).to eq(expected_console_messages)
-    # end
   end
 end

--- a/spec/game_looper_spec.rb
+++ b/spec/game_looper_spec.rb
@@ -32,7 +32,7 @@ end
 
 describe 'Game Looper' do
   context '#loop' do
-    it 'stops looping when the board is full' do
+    it 'loops until there is a draw' do
       console = TestConsole.new
       prompt = TestPrompt.new
       board = TestBoard.new
@@ -42,15 +42,42 @@ describe 'Game Looper' do
       players = [player_one, player_two]
 
       allow(board).to receive(:full?).and_return(false, false, false, false, true)
+      allow(board).to receive(:has_draw?).and_return(false, false, false, false, true)
+      allow(board).to receive(:has_win?).and_return(false, false, false, false, false)
 
-      allow(display).to receive(:present).and_return('board', 'board', 'full_board')
+      allow(display).to receive(:present).and_return('board', 'board', 'board_with_draw')
 
       game_looper = GameLooper.new(console:, prompt:, board:, display:,
                                    players:)
 
       game_looper.loop
 
-      expected_console_messages = %w[board board full_board]
+      expected_console_messages = %w[board board board_with_draw]
+
+      expect(console.messages).to eq(expected_console_messages)
+    end
+
+    it 'loops until there is a win' do
+      console = TestConsole.new
+      prompt = TestPrompt.new
+      board = TestBoard.new
+      display = TestDisplay.new
+      player_one = TestPlayer.new('X')
+      player_two = TestPlayer.new('O')
+      players = [player_one, player_two]
+
+      allow(board).to receive(:full?).and_return(false, false, false, false, true)
+      allow(board).to receive(:has_draw?).and_return(false, false, false, false, false)
+      allow(board).to receive(:has_win?).and_return(false, false, false, false, true)
+
+      allow(display).to receive(:present).and_return('board', 'board', 'board_with_win')
+
+      game_looper = GameLooper.new(console:, prompt:, board:, display:,
+                                   players:)
+
+      game_looper.loop
+
+      expected_console_messages = %w[board board board_with_win]
 
       expect(console.messages).to eq(expected_console_messages)
     end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -61,11 +61,11 @@ describe 'Game' do
       game = Game.new(console:, game_looper:)
 
       allow($stdin).to receive(:gets).and_return('9')
-      board.values = [ 
-                      'X', '0',  3, 
-                       4,  'X', 'O', 
-                       7,   8,   9 
-                    ]
+      board.values = [
+        'X', '0', 3,
+        4, 'X', 'O',
+        7, 8, 9
+      ]
 
       game.run
 
@@ -90,11 +90,11 @@ describe 'Game' do
       game = Game.new(console:, game_looper:)
 
       allow($stdin).to receive(:gets).and_return('7')
-      board.values = [ 
-                      'X', '0', '0', 
-                      'O', 'O', 'X', 
-                       7,  'X', 'O' 
-                    ]
+      board.values = [
+        'X', '0', '0',
+        'O', 'O', 'X',
+        7, 'X', 'O'
+      ]
 
       game.run
 

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -51,13 +51,13 @@ describe 'Game' do
       $stdout = StringIO.new
 
       console = Console.new(stdin: $stdin, stdout: $stdout)
-      outcome_checker = OutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
+      outcome_checker = OutcomeChecker.new(board:)
       number_validator = NumberValidator.new
       prompt = Prompt.new(console:, number_validator:, board:)
       display = Display.new
       players = [Player.new(marker: 'X'), Player.new(marker: 'O')]
-      game_looper = GameLooper.new(console:, display:, prompt:, board:, players:)
+      game_looper = GameLooper.new(console:, display:, prompt:, board:, players:, outcome_checker:)
       game = Game.new(console:, game_looper:)
 
       allow($stdin).to receive(:gets).and_return('9')
@@ -80,13 +80,13 @@ describe 'Game' do
       $stdout = StringIO.new
 
       console = Console.new(stdin: $stdin, stdout: $stdout)
-      outcome_checker = OutcomeChecker.new
-      board = Board.new(outcome_checker:)
+      board = Board.new
+      outcome_checker = OutcomeChecker.new(board:)
       number_validator = NumberValidator.new
       prompt = Prompt.new(console:, number_validator:, board:)
       display = Display.new
       players = [Player.new(marker: 'X'), Player.new(marker: 'O')]
-      game_looper = GameLooper.new(console:, display:, prompt:, board:, players:)
+      game_looper = GameLooper.new(console:, display:, prompt:, board:, players:, outcome_checker:)
       game = Game.new(console:, game_looper:)
 
       allow($stdin).to receive(:gets).and_return('7')

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -62,9 +62,9 @@ describe 'Game' do
 
       allow($stdin).to receive(:gets).and_return('9')
       board.values = [ 
-                      'X', '0', '0', 
-                      'X', 'X', 'O', 
-                      'O', 'O',  9 
+                      'X', '0',  3, 
+                       4,  'X', 'O', 
+                       7,   8,   9 
                     ]
 
       game.run

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -45,15 +45,14 @@ describe 'Game' do
       expected_output = ['Welcome to Tic Tac Toe!', 'Looping', 'Thank you for playing. Goodbye!']
       expect(console.messages).to eq(expected_output)
     end
-  end
 
-  context 'when the board is full' do
-    it 'exits the game' do
+    it 'exits the game when there is a win' do
       original_stdout = $stdout
       $stdout = StringIO.new
 
       console = Console.new(stdin: $stdin, stdout: $stdout)
-      board = Board.new
+      outcome_checker = OutcomeChecker.new
+      board = Board.new(outcome_checker:)
       number_validator = NumberValidator.new
       prompt = Prompt.new(console:, number_validator:, board:)
       display = Display.new
@@ -62,7 +61,40 @@ describe 'Game' do
       game = Game.new(console:, game_looper:)
 
       allow($stdin).to receive(:gets).and_return('9')
-      board.values = ['X', '0', '0', 'X', 'X', 'O', 'O', 'O', 9]
+      board.values = [ 
+                      'X', '0', '0', 
+                      'X', 'X', 'O', 
+                      'O', 'O',  9 
+                    ]
+
+      game.run
+
+      output = $stdout.string.split("\n")
+      expect(output).to include('Thank you for playing. Goodbye!')
+
+      $stdout = original_stdout
+    end
+
+    it 'exits the game when there is a draw' do
+      original_stdout = $stdout
+      $stdout = StringIO.new
+
+      console = Console.new(stdin: $stdin, stdout: $stdout)
+      outcome_checker = OutcomeChecker.new
+      board = Board.new(outcome_checker:)
+      number_validator = NumberValidator.new
+      prompt = Prompt.new(console:, number_validator:, board:)
+      display = Display.new
+      players = [Player.new(marker: 'X'), Player.new(marker: 'O')]
+      game_looper = GameLooper.new(console:, display:, prompt:, board:, players:)
+      game = Game.new(console:, game_looper:)
+
+      allow($stdin).to receive(:gets).and_return('7')
+      board.values = [ 
+                      'X', '0', '0', 
+                      'O', 'O', 'X', 
+                       7,  'X', 'O' 
+                    ]
 
       game.run
 

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -47,12 +47,12 @@ def rows_with_no_wins
     %w[X X O],
     ['X', 2, 'O']
   ]
-end 
+end
 
 def columns_with_one_win
   [
     ['O', 'X', 'X'],
-    ['X', 'X',  2 ],
+    ['X', 'X', 2],
     ['O', 'O', 'O']
   ]
 end
@@ -95,7 +95,7 @@ def full_columns_with_no_wins
   ]
 end
 
-def full_diagonals_with_no_wins 
+def full_diagonals_with_no_wins
   [
     %w[X X O],
     %w[O X X]
@@ -105,14 +105,16 @@ end
 describe 'Outcome Checker' do
   context '#win?' do
     it 'returns true with 1 winning row' do
-      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_no_wins, test_full: false)
+      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins,
+                            test_diagonals: diagonals_with_no_wins, test_full: false)
       outcome_checker = OutcomeChecker.new
 
       expect(outcome_checker.win?(board)).to eq(true)
     end
 
     it 'returns true with 1 winning column' do
-      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_one_win, test_diagonals: diagonals_with_no_wins, test_full: false)
+      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_one_win,
+                            test_diagonals: diagonals_with_no_wins, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 
@@ -120,7 +122,8 @@ describe 'Outcome Checker' do
     end
 
     it 'returns true with 1 winning diagonal' do
-      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_one_win, test_full: false)
+      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins,
+                            test_diagonals: diagonals_with_one_win, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 
@@ -128,7 +131,8 @@ describe 'Outcome Checker' do
     end
 
     it 'returns false with 0 winning rows, columns, or diagonals and an empty space' do
-      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_no_wins, test_full: false)
+      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins,
+                            test_diagonals: diagonals_with_no_wins, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 
@@ -136,7 +140,8 @@ describe 'Outcome Checker' do
     end
 
     it 'returns false with 0 winning rows, columns, or diagonals and no empty spaces' do
-      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins, test_diagonals: full_diagonals_with_no_wins, test_full: true)
+      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins,
+                            test_diagonals: full_diagonals_with_no_wins, test_full: true)
 
       outcome_checker = OutcomeChecker.new
 
@@ -146,7 +151,8 @@ describe 'Outcome Checker' do
 
   context '#draw?' do
     it 'returns true when the board is full and #win? is false' do
-      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins, test_diagonals: full_diagonals_with_no_wins, test_full: true)
+      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins,
+                            test_diagonals: full_diagonals_with_no_wins, test_full: true)
 
       outcome_checker = OutcomeChecker.new
 
@@ -154,7 +160,8 @@ describe 'Outcome Checker' do
     end
 
     it 'returns false when the board is not full' do
-      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_no_wins, test_full: false)
+      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins,
+                            test_diagonals: diagonals_with_no_wins, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -2,10 +2,10 @@ require 'outcome_checker'
 require 'pry'
 
 class TestBoardForOutcomeChecker
-  attr_accessor :test_lines, :test_full
+  attr_accessor :test_combinations, :test_full
 
-  def initialize(test_lines:, test_full:)
-    @test_lines = test_lines
+  def initialize(test_combinations:, test_full:)
+    @test_combinations = test_combinations
     @test_full = test_full
   end
 
@@ -15,8 +15,8 @@ class TestBoardForOutcomeChecker
 
   def available?; end
 
-  def lines
-    test_lines
+  def combinations
+    test_combinations
   end
 
   def full?
@@ -24,7 +24,7 @@ class TestBoardForOutcomeChecker
   end
 end
 
-def test_lines_win_with_full_board
+def test_combinations_win_with_full_board
   rows = [
     ['X', 'O', 'X'],
     ['O', 'X', 'O'],
@@ -36,7 +36,7 @@ def test_lines_win_with_full_board
   rows + columns + diagonals
 end
 
-def test_lines_win_with_open_spaces
+def test_combinations_win_with_open_spaces
   rows = [
     [ 1,  2, 'X'],
     [ 4, 'X', 6 ],
@@ -48,7 +48,7 @@ def test_lines_win_with_open_spaces
   rows + columns + diagonals
 end
 
-def test_lines_no_win_with_open_spaces
+def test_combinations_no_win_with_open_spaces
   rows = [
     [ 1,  2, 'X'],
     [ 4, 'O', 6 ],
@@ -60,7 +60,7 @@ def test_lines_no_win_with_open_spaces
   rows + columns + diagonals
 end
 
-def test_lines_draw
+def test_combinations_draw
   rows = [
     ['X', 'O', 'X'],
     ['O', 'O', 'X'],
@@ -76,7 +76,7 @@ describe 'Outcome Checker' do
   describe '#win?' do
     context 'with 1 winning line and a full board' do
       it 'returns true' do
-        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_full_board, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(true)
@@ -85,16 +85,16 @@ describe 'Outcome Checker' do
 
     context 'with 1 winning line and open spaces on the board' do
       it 'returns true' do
-        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_open_spaces, test_full: false)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_open_spaces, test_full: false)
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(true)
       end
     end
 
-    context 'with no winning lines and open spaces on the board' do
+    context 'with no winning combinations and open spaces on the board' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_no_win_with_open_spaces, test_full: false)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(false)
@@ -103,7 +103,7 @@ describe 'Outcome Checker' do
 
     context 'with a draw' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_draw, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(false)
@@ -114,7 +114,7 @@ describe 'Outcome Checker' do
   describe '#draw?' do
     context 'when the board is full and #win? is false' do
       it 'returns true' do
-        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_draw, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
 
         outcome_checker = OutcomeChecker.new(board:)
 
@@ -124,7 +124,7 @@ describe 'Outcome Checker' do
 
     context 'when the board is not full and #win? is false' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_no_win_with_open_spaces, test_full: false)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
 
         outcome_checker = OutcomeChecker.new(board:)
 
@@ -134,7 +134,7 @@ describe 'Outcome Checker' do
 
     context 'when the board is full and #win? is true' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_full_board, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
 
         outcome_checker = OutcomeChecker.new(board:)
 

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -71,7 +71,6 @@ describe 'Outcome Checker' do
   describe '#win?' do
     context 'with 1 winning line and a full board' do
       it 'returns true' do
-        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
         board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board)
 
         outcome_checker = OutcomeChecker.new(board:)
@@ -82,7 +81,6 @@ describe 'Outcome Checker' do
 
     context 'with 1 winning line and open spaces on the board' do
       it 'returns true' do
-        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_open_spaces, test_full: false)
         board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_open_spaces)
 
         outcome_checker = OutcomeChecker.new(board:)
@@ -93,7 +91,6 @@ describe 'Outcome Checker' do
 
     context 'with no winning combinations and open spaces on the board' do
       it 'returns false' do
-        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
         board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces)
 
         outcome_checker = OutcomeChecker.new(board:)
@@ -104,7 +101,6 @@ describe 'Outcome Checker' do
 
     context 'with a draw' do
       it 'returns false' do
-        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
         board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw)
 
         outcome_checker = OutcomeChecker.new(board:)
@@ -117,7 +113,6 @@ describe 'Outcome Checker' do
   describe '#draw?' do
     context 'when the board is full and #win? is false' do
       it 'returns true' do
-        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
         board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw)
 
         outcome_checker = OutcomeChecker.new(board:)
@@ -128,7 +123,6 @@ describe 'Outcome Checker' do
 
     context 'when the board is not full and #win? is false' do
       it 'returns false' do
-        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
         board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces)
 
         outcome_checker = OutcomeChecker.new(board:)
@@ -139,7 +133,6 @@ describe 'Outcome Checker' do
 
     context 'when the board is full and #win? is true' do
       it 'returns false' do
-        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
         board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board)
 
         outcome_checker = OutcomeChecker.new(board:)

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -2,11 +2,10 @@ require 'outcome_checker'
 require 'pry'
 
 class TestBoardForOutcomeChecker
-  attr_accessor :test_combinations, :test_full
+  attr_accessor :test_combinations
 
-  def initialize(test_combinations:, test_full:)
+  def initialize(test_combinations:)
     @test_combinations = test_combinations
-    @test_full = test_full
   end
 
   def get_space(_row, _column); end
@@ -17,10 +16,6 @@ class TestBoardForOutcomeChecker
 
   def combinations
     test_combinations
-  end
-
-  def full?
-    test_full
   end
 end
 
@@ -76,7 +71,9 @@ describe 'Outcome Checker' do
   describe '#win?' do
     context 'with 1 winning line and a full board' do
       it 'returns true' do
-        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
+        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board)
+
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(true)
@@ -85,7 +82,9 @@ describe 'Outcome Checker' do
 
     context 'with 1 winning line and open spaces on the board' do
       it 'returns true' do
-        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_open_spaces, test_full: false)
+        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_open_spaces, test_full: false)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_open_spaces)
+
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(true)
@@ -94,7 +93,9 @@ describe 'Outcome Checker' do
 
     context 'with no winning combinations and open spaces on the board' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
+        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces)
+
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(false)
@@ -103,7 +104,9 @@ describe 'Outcome Checker' do
 
     context 'with a draw' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
+        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw)
+
         outcome_checker = OutcomeChecker.new(board:)
 
         expect(outcome_checker.win?).to eq(false)
@@ -114,7 +117,8 @@ describe 'Outcome Checker' do
   describe '#draw?' do
     context 'when the board is full and #win? is false' do
       it 'returns true' do
-        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
+        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_draw)
 
         outcome_checker = OutcomeChecker.new(board:)
 
@@ -124,7 +128,8 @@ describe 'Outcome Checker' do
 
     context 'when the board is not full and #win? is false' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
+        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces, test_full: false)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_no_win_with_open_spaces)
 
         outcome_checker = OutcomeChecker.new(board:)
 
@@ -134,7 +139,8 @@ describe 'Outcome Checker' do
 
     context 'when the board is full and #win? is true' do
       it 'returns false' do
-        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
+        # board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board, test_full: true)
+        board = TestBoardForOutcomeChecker.new(test_combinations: test_combinations_win_with_full_board)
 
         outcome_checker = OutcomeChecker.new(board:)
 

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -2,42 +2,117 @@ require 'outcome_checker'
 require 'pry'
 
 class TestBoard
+  attr_accessor :test_rows, :test_columns, :test_diagonals, :test_full
+
+  def initialize(test_rows: [], test_columns: [], test_diagonals: [], test_full: false)
+    @test_rows = test_rows
+    @test_columns = test_columns
+    @test_diagonals = test_diagonals
+    @test_full = test_full
+  end
+
   def get_space(row, column)
     index = (row * 3) + column
     values[index]
   end
+
+  def rows
+    test_rows
+  end
+
+  def columns
+    test_columns
+  end
+
+  def diagonals
+    test_diagonals
+  end
+
+  def full?
+    test_full
+  end
+end
+
+def rows_with_one_win
+  [
+    %w[X X X],
+    %w[O X O],
+    ['O', 8, 'O']
+  ]
+end
+
+def rows_with_no_wins
+  [
+    %w[O X O],
+    %w[X X O],
+    ['X', 2, 'O']
+  ]
+end 
+
+def columns_with_one_win
+  [
+    ['O', 'X', 'X'],
+    ['X', 'X',  2 ],
+    ['O', 'O', 'O']
+  ]
+end
+
+def columns_with_no_wins
+  [
+    %w[X O O],
+    [2,  'X', 8],
+    %w[X O X]
+  ]
+end
+
+def diagonals_with_one_win
+  [
+    %w[X X X],
+    %w[X X O]
+  ]
+end
+
+def diagonals_with_no_wins
+  [
+    %w[X O X],
+    %w[X X O]
+  ]
+end
+
+def full_rows_with_no_wins
+  [
+    %w[X O X],
+    %w[O X X],
+    %w[O X O]
+  ]
+end
+
+def full_columns_with_no_wins
+  [
+    %w[X O O],
+    %w[O X X],
+    %w[X X O]
+  ]
+end
+
+def full_diagonals_with_no_wins 
+  [
+    %w[X X O],
+    %w[O X X]
+  ]
 end
 
 describe 'Outcome Checker' do
   context '#win?' do
     it 'returns true with 1 winning row' do
-      board = TestBoard.new
-      rows_with_one_winning_row = [
-        %w[X X X],
-        %w[O X O],
-        ['O', 8, 'O']
-      ]
-      allow(board).to receive(:rows).and_return(rows_with_one_winning_row)
-
+      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_no_wins, test_full: false)
       outcome_checker = OutcomeChecker.new
 
       expect(outcome_checker.win?(board)).to eq(true)
     end
 
     it 'returns true with 1 winning column' do
-      board = TestBoard.new
-      rows_with_no_winning_rows = [
-        %w[O X O],
-        %w[X X O],
-        ['X', 2, 'O']
-      ]
-      columns_with_one_winning_column = [
-        %w[O X X],
-        ['X', 'X', 2],
-        %w[O O O]
-      ]
-      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
-      allow(board).to receive(:columns).and_return(columns_with_one_winning_column)
+      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_one_win, test_diagonals: diagonals_with_no_wins, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 
@@ -45,24 +120,7 @@ describe 'Outcome Checker' do
     end
 
     it 'returns true with 1 winning diagonal' do
-      board = TestBoard.new
-      rows_with_no_winning_rows = [
-        ['X', 2, 'X'],
-        %w[O X O],
-        ['O', 8, 'X']
-      ]
-      columns_with_no_winning_columns = [
-        %w[X O O],
-        [2,  'X', 8],
-        %w[X O X]
-      ]
-      diagonals_with_one_winning_diagonal = [
-        %w[X X X],
-        %w[X X O]
-      ]
-      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
-      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
-      allow(board).to receive(:diagonals).and_return(diagonals_with_one_winning_diagonal)
+      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_one_win, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 
@@ -70,24 +128,7 @@ describe 'Outcome Checker' do
     end
 
     it 'returns false with 0 winning rows, columns, or diagonals and an empty space' do
-      board = TestBoard.new
-      rows_with_no_winning_rows = [
-        %w[X O X],
-        %w[O X X],
-        ['O', 8, 'O']
-      ]
-      columns_with_no_winning_columns = [
-        %w[X O O],
-        ['O', 'X', 8],
-        %w[X X O]
-      ]
-      diagonals_with_no_winning_diagonals = [
-        %w[X X O],
-        %w[O X X]
-      ]
-      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
-      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
-      allow(board).to receive(:diagonals).and_return(diagonals_with_no_winning_diagonals)
+      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_no_wins, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 
@@ -95,24 +136,7 @@ describe 'Outcome Checker' do
     end
 
     it 'returns false with 0 winning rows, columns, or diagonals and no empty spaces' do
-      board = TestBoard.new
-      rows_with_no_winning_rows = [
-        %w[X O X],
-        %w[O X X],
-        %w[O X O]
-      ]
-      columns_with_no_winning_columns = [
-        %w[X O O],
-        %w[O X X],
-        %w[X X O]
-      ]
-      diagonals_with_no_winning_diagonals = [
-        %w[X X O],
-        %w[O X X]
-      ]
-      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
-      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
-      allow(board).to receive(:diagonals).and_return(diagonals_with_no_winning_diagonals)
+      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins, test_diagonals: full_diagonals_with_no_wins, test_full: true)
 
       outcome_checker = OutcomeChecker.new
 
@@ -122,25 +146,7 @@ describe 'Outcome Checker' do
 
   context '#draw?' do
     it 'returns true when the board is full and #win? is false' do
-      board = TestBoard.new
-      rows_with_no_winning_rows = [
-        %w[X O X],
-        %w[O X X],
-        %w[O X O]
-      ]
-      columns_with_no_winning_columns = [
-        %w[X O O],
-        %w[O X X],
-        %w[X X O]
-      ]
-      diagonals_with_no_winning_diagonals = [
-        %w[X X O],
-        %w[O X X]
-      ]
-      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
-      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
-      allow(board).to receive(:diagonals).and_return(diagonals_with_no_winning_diagonals)
-      allow(board).to receive(:full?).and_return(true)
+      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins, test_diagonals: full_diagonals_with_no_wins, test_full: true)
 
       outcome_checker = OutcomeChecker.new
 
@@ -148,8 +154,7 @@ describe 'Outcome Checker' do
     end
 
     it 'returns false when the board is not full' do
-      board = TestBoard.new
-      allow(board).to receive(:full?).and_return(false)
+      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins, test_diagonals: diagonals_with_no_wins, test_full: false)
 
       outcome_checker = OutcomeChecker.new
 
@@ -157,14 +162,7 @@ describe 'Outcome Checker' do
     end
 
     it 'returns false when the board is full and #win? is true' do
-      board = TestBoard.new
-      rows_with_one_winning_row = [
-        %w[X X X],
-        %w[O X O],
-        %w[O O O]
-      ]
-      allow(board).to receive(:full?).and_return(true)
-      allow(board).to receive(:rows).and_return(rows_with_one_winning_row)
+      board = TestBoard.new(test_rows: rows_with_one_win, test_full: true)
 
       outcome_checker = OutcomeChecker.new
 

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -22,10 +22,6 @@ class TestBoardForOutcomeChecker
   def full?
     test_full
   end
-
-  def has_win?; end
-
-  def has_draw?; end
 end
 
 def test_lines_win_with_full_board

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -29,7 +29,11 @@ class TestBoardForOutcomeChecker
 end
 
 def test_lines_win_with_full_board
-  rows = [ ['X', 'O', 'X'], ['O', 'X', 'O'], ['X', 'X', 'O'] ]
+  rows = [
+    ['X', 'O', 'X'],
+    ['O', 'X', 'O'],
+    ['X', 'X', 'O']
+  ]
   columns = rows.transpose
   diagonals = [ ['X', 'X', 'O'], ['X', 'X', 'X']]
 
@@ -37,23 +41,35 @@ def test_lines_win_with_full_board
 end
 
 def test_lines_win_with_open_spaces
-  rows = [ ['X', 'O', 'X'], ['O', 'X', 'O'], ['X', 8, 9]]
+  rows = [
+    [ 1,  2, 'X'],
+    [ 4, 'X', 6 ],
+    ['X', 8,  9 ]
+  ]
   columns = rows.transpose
-  diagonals = [['X', 'X', 9], ['X', 'X', 'X']]
+  diagonals = [ [1, 'X', 9], ['X', 'X', 'X'] ]
 
   rows + columns + diagonals
 end
 
 def test_lines_no_win_with_open_spaces
-  rows = [['X', 'O', 'X'], ['O', 'O', 'X'], ['X', 8, 9]]
+  rows = [
+    [ 1,  2, 'X'],
+    [ 4, 'O', 6 ],
+    ['X', 8,  9 ]
+  ]
   columns = rows.transpose
-  diagonals = [['X', 'O', 9], ['X', 'O', 'X']]
+  diagonals = [ [1, 'O', 9], ['X', 'O', 'X'] ]
 
   rows + columns + diagonals
 end
 
 def test_lines_draw
-  rows = [['X', 'O', 'X'], ['O', 'O', 'X'], ['X', 'X', 'O']]
+  rows = [
+    ['X', 'O', 'X'],
+    ['O', 'O', 'X'],
+    ['X', 'X', 'O']
+  ]
   columns = rows.transpose
   diagonals = [['X', 'O', 'O'], ['X', 'O', 'X']]
 

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -1,0 +1,174 @@
+require 'outcome_checker'
+require 'pry'
+
+class TestBoard
+  def get_space(row, column)
+    index = (row * 3) + column
+    values[index]
+  end
+end
+
+describe 'Outcome Checker' do
+  context '#win?' do
+    it 'returns true with 1 winning row' do
+      board = TestBoard.new
+      rows_with_one_winning_row = [
+        %w[X X X],
+        %w[O X O],
+        ['O', 8, 'O']
+      ]
+      allow(board).to receive(:rows).and_return(rows_with_one_winning_row)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.win?(board)).to eq(true)
+    end
+
+    it 'returns true with 1 winning column' do
+      board = TestBoard.new
+      rows_with_no_winning_rows = [
+        %w[O X O],
+        %w[X X O],
+        ['X', 2, 'O']
+      ]
+      columns_with_one_winning_column = [
+        %w[O X X],
+        ['X', 'X', 2],
+        %w[O O O]
+      ]
+      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
+      allow(board).to receive(:columns).and_return(columns_with_one_winning_column)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.win?(board)).to eq(true)
+    end
+
+    it 'returns true with 1 winning diagonal' do
+      board = TestBoard.new
+      rows_with_no_winning_rows = [
+        ['X', 2, 'X'],
+        %w[O X O],
+        ['O', 8, 'X']
+      ]
+      columns_with_no_winning_columns = [
+        %w[X O O],
+        [2,  'X', 8],
+        %w[X O X]
+      ]
+      diagonals_with_one_winning_diagonal = [
+        %w[X X X],
+        %w[X X O]
+      ]
+      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
+      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
+      allow(board).to receive(:diagonals).and_return(diagonals_with_one_winning_diagonal)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.win?(board)).to eq(true)
+    end
+
+    it 'returns false with 0 winning rows, columns, or diagonals and an empty space' do
+      board = TestBoard.new
+      rows_with_no_winning_rows = [
+        %w[X O X],
+        %w[O X X],
+        ['O', 8, 'O']
+      ]
+      columns_with_no_winning_columns = [
+        %w[X O O],
+        ['O', 'X', 8],
+        %w[X X O]
+      ]
+      diagonals_with_no_winning_diagonals = [
+        %w[X X O],
+        %w[O X X]
+      ]
+      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
+      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
+      allow(board).to receive(:diagonals).and_return(diagonals_with_no_winning_diagonals)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.win?(board)).to eq(false)
+    end
+
+    it 'returns false with 0 winning rows, columns, or diagonals and no empty spaces' do
+      board = TestBoard.new
+      rows_with_no_winning_rows = [
+        %w[X O X],
+        %w[O X X],
+        %w[O X O]
+      ]
+      columns_with_no_winning_columns = [
+        %w[X O O],
+        %w[O X X],
+        %w[X X O]
+      ]
+      diagonals_with_no_winning_diagonals = [
+        %w[X X O],
+        %w[O X X]
+      ]
+      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
+      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
+      allow(board).to receive(:diagonals).and_return(diagonals_with_no_winning_diagonals)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.win?(board)).to eq(false)
+    end
+  end
+
+  context '#draw?' do
+    it 'returns true when the board is full and #win? is false' do
+      board = TestBoard.new
+      rows_with_no_winning_rows = [
+        %w[X O X],
+        %w[O X X],
+        %w[O X O]
+      ]
+      columns_with_no_winning_columns = [
+        %w[X O O],
+        %w[O X X],
+        %w[X X O]
+      ]
+      diagonals_with_no_winning_diagonals = [
+        %w[X X O],
+        %w[O X X]
+      ]
+      allow(board).to receive(:rows).and_return(rows_with_no_winning_rows)
+      allow(board).to receive(:columns).and_return(columns_with_no_winning_columns)
+      allow(board).to receive(:diagonals).and_return(diagonals_with_no_winning_diagonals)
+      allow(board).to receive(:full?).and_return(true)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.draw?(board)).to eq(true)
+    end
+
+    it 'returns false when the board is not full' do
+      board = TestBoard.new
+      allow(board).to receive(:full?).and_return(false)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.draw?(board)).to eq(false)
+    end
+
+    it 'returns false when the board is full and #win? is true' do
+      board = TestBoard.new
+      rows_with_one_winning_row = [
+        %w[X X X],
+        %w[O X O],
+        %w[O O O]
+      ]
+      allow(board).to receive(:full?).and_return(true)
+      allow(board).to receive(:rows).and_return(rows_with_one_winning_row)
+
+      outcome_checker = OutcomeChecker.new
+
+      expect(outcome_checker.draw?(board)).to eq(false)
+    end
+  end
+end

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -9,12 +9,11 @@ class TestBoardForOutcomeChecker
     @test_full = test_full
   end
 
-  def get_space(row, column)
-    index = (row * 3) + column
-    values[index]
-  end
+  def get_space(_row, _column); end
 
   def mark_space(token, space); end
+
+  def available?; end
 
   def lines
     test_lines
@@ -24,7 +23,9 @@ class TestBoardForOutcomeChecker
     test_full
   end
 
-  def available?; end
+  def has_win?; end
+  
+  def has_draw?; end
 end
 
 def test_lines_win_with_full_board
@@ -64,36 +65,36 @@ describe 'Outcome Checker' do
     context 'with 1 winning line and a full board' do
       it 'returns true' do
         board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_full_board, test_full: true)
-        outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new(board:)
 
-        expect(outcome_checker.win?(board)).to eq(true)
+        expect(outcome_checker.win?).to eq(true)
       end
     end
 
     context 'with 1 winning line and open spaces on the board' do
       it 'returns true' do
         board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_open_spaces, test_full: false)
-        outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new(board:)
 
-        expect(outcome_checker.win?(board)).to eq(true)
+        expect(outcome_checker.win?).to eq(true)
       end
     end
 
     context 'with no winning lines and open spaces on the board' do
       it 'returns false' do
         board = TestBoardForOutcomeChecker.new(test_lines: test_lines_no_win_with_open_spaces, test_full: false)
-        outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new(board:)
 
-        expect(outcome_checker.win?(board)).to eq(false)
+        expect(outcome_checker.win?).to eq(false)
       end
     end
 
     context 'with a draw' do
       it 'returns false' do
         board = TestBoardForOutcomeChecker.new(test_lines: test_lines_draw, test_full: true)
-        outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new(board:)
 
-        expect(outcome_checker.win?(board)).to eq(false)
+        expect(outcome_checker.win?).to eq(false)
       end
     end
   end
@@ -103,9 +104,9 @@ describe 'Outcome Checker' do
       it 'returns true' do
         board = TestBoardForOutcomeChecker.new(test_lines: test_lines_draw, test_full: true)
 
-        outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new(board:)
 
-        expect(outcome_checker.draw?(board)).to eq(true)
+        expect(outcome_checker.draw?).to eq(true)
       end
     end
 
@@ -113,9 +114,9 @@ describe 'Outcome Checker' do
       it 'returns false' do
         board = TestBoardForOutcomeChecker.new(test_lines: test_lines_no_win_with_open_spaces, test_full: false)
 
-        outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new(board:)
 
-        expect(outcome_checker.draw?(board)).to eq(false)
+        expect(outcome_checker.draw?).to eq(false)
       end
     end
 
@@ -123,9 +124,9 @@ describe 'Outcome Checker' do
       it 'returns false' do
         board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_full_board, test_full: true)
 
-        outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new(board:)
 
-        expect(outcome_checker.draw?(board)).to eq(false)
+        expect(outcome_checker.draw?).to eq(false)
       end
     end
   end

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -24,7 +24,7 @@ class TestBoardForOutcomeChecker
   end
 
   def has_win?; end
-  
+
   def has_draw?; end
 end
 

--- a/spec/outcome_checker_spec.rb
+++ b/spec/outcome_checker_spec.rb
@@ -1,13 +1,11 @@
 require 'outcome_checker'
 require 'pry'
 
-class TestBoard
-  attr_accessor :test_rows, :test_columns, :test_diagonals, :test_full
+class TestBoardForOutcomeChecker
+  attr_accessor :test_lines, :test_full
 
-  def initialize(test_rows: [], test_columns: [], test_diagonals: [], test_full: false)
-    @test_rows = test_rows
-    @test_columns = test_columns
-    @test_diagonals = test_diagonals
+  def initialize(test_lines:, test_full:)
+    @test_lines = test_lines
     @test_full = test_full
   end
 
@@ -16,164 +14,119 @@ class TestBoard
     values[index]
   end
 
-  def rows
-    test_rows
-  end
+  def mark_space(token, space); end
 
-  def columns
-    test_columns
-  end
-
-  def diagonals
-    test_diagonals
+  def lines
+    test_lines
   end
 
   def full?
     test_full
   end
+
+  def available?; end
 end
 
-def rows_with_one_win
-  [
-    %w[X X X],
-    %w[O X O],
-    ['O', 8, 'O']
-  ]
+def test_lines_win_with_full_board
+  rows = [ ['X', 'O', 'X'], ['O', 'X', 'O'], ['X', 'X', 'O'] ]
+  columns = rows.transpose
+  diagonals = [ ['X', 'X', 'O'], ['X', 'X', 'X']]
+
+  rows + columns + diagonals
 end
 
-def rows_with_no_wins
-  [
-    %w[O X O],
-    %w[X X O],
-    ['X', 2, 'O']
-  ]
+def test_lines_win_with_open_spaces
+  rows = [ ['X', 'O', 'X'], ['O', 'X', 'O'], ['X', 8, 9]]
+  columns = rows.transpose
+  diagonals = [['X', 'X', 9], ['X', 'X', 'X']]
+
+  rows + columns + diagonals
 end
 
-def columns_with_one_win
-  [
-    ['O', 'X', 'X'],
-    ['X', 'X', 2],
-    ['O', 'O', 'O']
-  ]
+def test_lines_no_win_with_open_spaces
+  rows = [['X', 'O', 'X'], ['O', 'O', 'X'], ['X', 8, 9]]
+  columns = rows.transpose
+  diagonals = [['X', 'O', 9], ['X', 'O', 'X']]
+
+  rows + columns + diagonals
 end
 
-def columns_with_no_wins
-  [
-    %w[X O O],
-    [2,  'X', 8],
-    %w[X O X]
-  ]
-end
+def test_lines_draw
+  rows = [['X', 'O', 'X'], ['O', 'O', 'X'], ['X', 'X', 'O']]
+  columns = rows.transpose
+  diagonals = [['X', 'O', 'O'], ['X', 'O', 'X']]
 
-def diagonals_with_one_win
-  [
-    %w[X X X],
-    %w[X X O]
-  ]
-end
-
-def diagonals_with_no_wins
-  [
-    %w[X O X],
-    %w[X X O]
-  ]
-end
-
-def full_rows_with_no_wins
-  [
-    %w[X O X],
-    %w[O X X],
-    %w[O X O]
-  ]
-end
-
-def full_columns_with_no_wins
-  [
-    %w[X O O],
-    %w[O X X],
-    %w[X X O]
-  ]
-end
-
-def full_diagonals_with_no_wins
-  [
-    %w[X X O],
-    %w[O X X]
-  ]
+  rows + columns + diagonals
 end
 
 describe 'Outcome Checker' do
-  context '#win?' do
-    it 'returns true with 1 winning row' do
-      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins,
-                            test_diagonals: diagonals_with_no_wins, test_full: false)
-      outcome_checker = OutcomeChecker.new
+  describe '#win?' do
+    context 'with 1 winning line and a full board' do
+      it 'returns true' do
+        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_full_board, test_full: true)
+        outcome_checker = OutcomeChecker.new
 
-      expect(outcome_checker.win?(board)).to eq(true)
+        expect(outcome_checker.win?(board)).to eq(true)
+      end
     end
 
-    it 'returns true with 1 winning column' do
-      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_one_win,
-                            test_diagonals: diagonals_with_no_wins, test_full: false)
+    context 'with 1 winning line and open spaces on the board' do
+      it 'returns true' do
+        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_open_spaces, test_full: false)
+        outcome_checker = OutcomeChecker.new
 
-      outcome_checker = OutcomeChecker.new
-
-      expect(outcome_checker.win?(board)).to eq(true)
+        expect(outcome_checker.win?(board)).to eq(true)
+      end
     end
 
-    it 'returns true with 1 winning diagonal' do
-      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins,
-                            test_diagonals: diagonals_with_one_win, test_full: false)
+    context 'with no winning lines and open spaces on the board' do
+      it 'returns false' do
+        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_no_win_with_open_spaces, test_full: false)
+        outcome_checker = OutcomeChecker.new
 
-      outcome_checker = OutcomeChecker.new
-
-      expect(outcome_checker.win?(board)).to eq(true)
+        expect(outcome_checker.win?(board)).to eq(false)
+      end
     end
 
-    it 'returns false with 0 winning rows, columns, or diagonals and an empty space' do
-      board = TestBoard.new(test_rows: rows_with_no_wins, test_columns: columns_with_no_wins,
-                            test_diagonals: diagonals_with_no_wins, test_full: false)
+    context 'with a draw' do
+      it 'returns false' do
+        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_draw, test_full: true)
+        outcome_checker = OutcomeChecker.new
 
-      outcome_checker = OutcomeChecker.new
-
-      expect(outcome_checker.win?(board)).to eq(false)
-    end
-
-    it 'returns false with 0 winning rows, columns, or diagonals and no empty spaces' do
-      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins,
-                            test_diagonals: full_diagonals_with_no_wins, test_full: true)
-
-      outcome_checker = OutcomeChecker.new
-
-      expect(outcome_checker.win?(board)).to eq(false)
+        expect(outcome_checker.win?(board)).to eq(false)
+      end
     end
   end
 
-  context '#draw?' do
-    it 'returns true when the board is full and #win? is false' do
-      board = TestBoard.new(test_rows: full_rows_with_no_wins, test_columns: full_columns_with_no_wins,
-                            test_diagonals: full_diagonals_with_no_wins, test_full: true)
+  describe '#draw?' do
+    context 'when the board is full and #win? is false' do
+      it 'returns true' do
+        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_draw, test_full: true)
 
-      outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new
 
-      expect(outcome_checker.draw?(board)).to eq(true)
+        expect(outcome_checker.draw?(board)).to eq(true)
+      end
     end
 
-    it 'returns false when the board is not full' do
-      board = TestBoard.new(test_rows: rows_with_one_win, test_columns: columns_with_no_wins,
-                            test_diagonals: diagonals_with_no_wins, test_full: false)
+    context 'when the board is not full and #win? is false' do
+      it 'returns false' do
+        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_no_win_with_open_spaces, test_full: false)
 
-      outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new
 
-      expect(outcome_checker.draw?(board)).to eq(false)
+        expect(outcome_checker.draw?(board)).to eq(false)
+      end
     end
 
-    it 'returns false when the board is full and #win? is true' do
-      board = TestBoard.new(test_rows: rows_with_one_win, test_full: true)
+    context 'when the board is full and #win? is true' do
+      it 'returns false' do
+        board = TestBoardForOutcomeChecker.new(test_lines: test_lines_win_with_full_board, test_full: true)
 
-      outcome_checker = OutcomeChecker.new
+        outcome_checker = OutcomeChecker.new
 
-      expect(outcome_checker.draw?(board)).to eq(false)
+        expect(outcome_checker.draw?(board)).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
The following has been added in this pull request:

- The game is a draw when there are no more available spaces
- The game has a winner when there are three spaces in a row with the same token
- Three tokens can be a column, row, or diagonal
- No more tokens can be added to the game once there is an outcome

The Board#left_diagonal and Board#right_diagonal methods are currently longer than 5 lines but I'm not sure how to shorten them while still making them independent of board size. 

I'm working on the "it gives each player a turn" test in Game Looper Spec and refactoring to build my own test doubles instead of using method stubs. It's taking a bit of time so I figured I'd include it in the next PR.

Thanks!